### PR TITLE
[doc] 메타 태그 내용 보완

### DIFF
--- a/docs/nuxt/meta-tags.md
+++ b/docs/nuxt/meta-tags.md
@@ -14,14 +14,15 @@ title: Meta Tags
 // nuxt.config.js
 export default {
   head: {
-    title: 'learn-nuxt',
+    title: 'Cracking Vue.js',
     htmlAttrs: {
       lang: 'en',
     },
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { hid: 'description', name: 'description', content: '' },
+      { hid: 'description', name: 'description', content: 'Vue.js 오픈소스 개발과 관련된 정보를 얻을 수 있는 사이트입니다.' },
+      { hid: 'keywords', name: 'keywords', content: 'JavaScript, Vue.js, Nuxt.js, TypeScript, VuePress' },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
   },
@@ -33,10 +34,11 @@ export default {
 ```html
 <html lang="en">
 <head>
-  <title>페이지 타이틀입니다</title>
+  <title>Cracking Vue.js</title>
   <meta data-n-head="ssr" charset="utf-8">
   <meta data-n-head="ssr" name="viewport" content="width=device-width, initial-scale=1">
-  <meta data-n-head="ssr" data-hid="description" name="description" content="">
+  <meta data-n-head="ssr" data-hid="description" name="description" content="Vue.js 오픈소스 개발과 관련된 정보를 얻을 수 있는 사이트입니다.">
+  <meta data-n-head="ssr" data-hid="keywords" name="keywords" content="JavaScript, Vue.js, Nuxt.js, TypeScript, VuePress">
   <link data-n-head="ssr" rel="icon" type="image/x-icon" href="/favicon.ico">
 </head>
 <!-- ... -->
@@ -49,22 +51,26 @@ export default {
 페이지별로 다른 head 태그를 설정하고 싶은 경우에는 각 페이지 컴포넌트에 아래와 같은 속성을 추가합니다.
 
 ```html
-<!-- page/home.vue -->
+<!-- page/review/index.vue -->
 <script>
 export default {
   data() {
     return {
-      str: 'hi'
+      reviews: [],
     }
   },
-
   head: {
-    title: '페이지 타이틀',
+    title: '실시간 후기',
     meta: [
       {
         hid: 'description',
         name: 'description',
-        content: '페이지 설명 내용',
+        content: '실시간 후기를 확인해보세요.',
+      },
+      {
+        hid: 'keywords',
+        name: 'keywords',
+        content: '과자, 과자 후기, 실시간 후기',
       },
     ],
     link: [

--- a/docs/nuxt/meta-tags.md
+++ b/docs/nuxt/meta-tags.md
@@ -44,6 +44,19 @@ export default {
 <!-- ... -->
 ```
 
+:::tip
+페이지별로 동일한 타이틀을 설정하고 싶다면, `titleTemplate`을 활용해 보세요.
+```js{4}
+// nuxt.config.js
+export default {
+  head: {
+    titleTemplate: '%s | Cracking Vue.js',
+  },
+  meta: [...],
+}
+```
+:::
+
 이 설정은 모든 페이지에 동일하게 적용됩니다. 여기서 페이지별로 다른 head 태그를 설정하고 싶다면 어떻게 해야 할까요?
 
 ## 페이지별 head 태그 설정


### PR DESCRIPTION
## 요약
메타 태그 내용을 조금 보완해봤습니다.
저도 이 부분을 준비하고 있었는데, 멘토님이 적어주신 내용이 훨씬 좋네요👍
1. 예시 보완
    - **페이지 head 태그 설정** 부분을 **Cracking Vue.js 예시**로 변경했습니다.
    - **페이지별 head 태그 설정** 부분을 `pages/products/_id.vue` 예시와 이어지도록 **실시간 후기 페이지 예시**로 변경했습니다.
    - **keywords 예시**를 추가했습니다.

2. titleTemplate 내용 tip 추가
    - 기타 meta 태그 설정 방법 중 vue-meta 속성 사이트에 있는 내용이긴 한데요.
    `titleTemplate`은 기타 방법들 중 자주 사용된다고 생각해서 tip으로 추가했습니다.
      Q. tip 안에 코드를 넣으니 조금 안 예쁜 것 같은데, 좋은 방법이 있을까요?🤔
        <img width="759" alt="스크린샷 2021-08-15 오후 8 25 58" src="https://user-images.githubusercontent.com/19399338/129476898-fb25dda7-d4d7-4aea-b003-295ca29fcbef.png">
