### PR TITLE
[doc] textbook.md 자바스크립트 기본 링크 수정

### DIFF
--- a/docs/textbook.md
+++ b/docs/textbook.md
@@ -9,7 +9,7 @@ title: Introduction
 
 ### 📖 입문
 
-- [자바스크립트 기본](/js/object.html)
+- [자바스크립트 기본](/js/variable.html)
 - [ES6](/es6/const-let.html)
 - [Vue.js 기본](/vue/instance.html)
 


### PR DESCRIPTION

## 요약

Introduction 페이지의 입문 > 자바스크립트 기본의 링크가
중간의 Object 페이지로 연결 되고 있어서, 첫번째인 Variable 페이지로 연결 되도록 수정 했습니다.
