### PR TITLE
[tool] Vercel Preview를 위한 vercel.json 설정 값 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ typings/
 .next
 
 .DS_Store
+
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/vue-camp/(.*)", "destination": "/$1" }
+  ]
+}


### PR DESCRIPTION
## 관련 이슈
#32 

## 요약

현재 vuepress의 `config.js`의 base 옵션을 사용하기 때문에 빌드하면 리소스들의 소스가 `/vue-camp/AAA`로 맵핑 됩니다.

따라서 Vercel 에서 `/docs/.vuepress/dist`디렉토리를 타겟으로 배포시 

실제 리소스의 경로는 `/AAA/BBB.js` 이지만 `/vue-camp/AAA/BBB.js`로 요청을 하여 로드가 불가능 합니다.

따라서 `/vue-camp/AAA`의 요청이 있을때 `/AAA`의 요청으로 [rewrite](https://vercel.com/docs/configuration#project/rewrites) 하는 config를 추가 하였습니다. (vercel.json)

### Vercel project settings
![image](https://user-images.githubusercontent.com/46892438/130382573-569cd32f-ff13-4b8c-8315-b2144f793b44.png)



### Example
[마스터 브랜치 Deployment](https://vue-camp.vercel.app/)
[PR에 대한 프리뷰 예시](https://github.com/juicyjusung/vue-camp/pull/2)

## 리뷰어

<!-- 해당 PR을 리뷰해 주었으면 하는 분들을 넣어주세요. 멘토 분들은 자동으로 코드 리뷰어에 들어가 있어서 멘티 분들 중에서 같이 봐주셨으면 하는 분들 지정해 주시면 됩니다 :) -->