### PR TITLE
[tool] manifest 이름 Cracking Vue.js로 변경

### DIFF
--- a/docs/.vuepress/public/manifest.json
+++ b/docs/.vuepress/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "Cracking Vue.js",
-  "name": "JavaScript, ES6, Vue, Vuex",
+  "name": "Cracking Vue.js",
   "icons": [
     {
       "src": "images/icons/72x.png",


### PR DESCRIPTION
## 요약
앱 이름에 description내용이 들어가 있어서 **Cracking Vue.js**로 변경했습니다.
<img width="109" alt="스크린샷 2021-09-10 오후 1 59 44" src="https://user-images.githubusercontent.com/19399338/132835496-98ac02dc-0af4-4647-a008-a84312813a8b.png">
